### PR TITLE
feat: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'  # Trigger on version tags
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload dist/* 


### PR DESCRIPTION
# Automatic PyPI Publishing Workflow

This PR implements automatic package publishing to PyPI when changes are merged to main or version tags are pushed. This addresses issue #2.

## Changes Made
- Added GitHub Actions workflow file `.github/workflows/publish.yml`
- Configured workflow to trigger on:
  - Pushes to `main` branch
  - Any tag starting with 'v' (e.g., v0.1.0)

## Implementation Details
The workflow:
1. Runs on Ubuntu latest
2. Sets up Python environment
3. Installs required publishing tools (build, twine)
4. Builds the package using `python -m build`
5. Publishes to PyPI using the stored API token

## Required Setup Before Merging
1. Create a PyPI API token at https://pypi.org/manage/account/
2. Add the token to GitHub repository secrets:
   - Name: `PYPI_API_TOKEN`
   - Value: Your PyPI token

## Testing After Merge
1. Create and push a test version tag:
   ```bash
   git tag v0.1.0-test
   git push origin v0.1.0-test
   ```
2. Watch the GitHub Actions workflow run
3. Verify package appears on PyPI

## Future Usage
For future releases:
1. Update version in `pyproject.toml`
2. Create and push a version tag:
   ```bash
   git tag v0.1.0
   git push origin v0.1.0
   ```

Closes #2